### PR TITLE
Update 100-prime_factor.c

### DIFF
--- a/0x04-more_functions_nested_loops/100-prime_factor.c
+++ b/0x04-more_functions_nested_loops/100-prime_factor.c
@@ -7,12 +7,21 @@
 int main(void)
 {
 	unsigned long int i = 3, n = 612852475143;
+	// The loop, why don't you have this instead
+	 for (unsigned long i = 2; i * i <= n; i++) {
+        while (n % i == 0) {
+            n /= i;
+        }
+    }
 
-	for (; i < 12057; i += 2)
-	{
-		while (n % i == 0 && n != i)
-			n /= i;
-	}
+// 	for (; i < 12057; i += 2)
+// 	{
+// 		while (n % i == 0 && n != i)
+// 			n /= i;
+// 	}
 	printf("%lu\n", n);
 	return (0);
 }
+
+
+


### PR DESCRIPTION
we start the loop counter i from 2 instead of 3, and we check the condition i * i <= n instead of i < 12057. This is because if n is not a prime number, one of its prime factors must be less than or equal to the square root of n.

Inside the loop, we simplify the condition to check if n is divisible by i. If it is, we divide n by i until it is no longer divisible by i.

Finally, we print the value of n after the loop.